### PR TITLE
Updating nonGS wikis as of 30 May 2025.

### DIFF
--- a/morebits.js
+++ b/morebits.js
@@ -144,7 +144,6 @@ MorebitsGlobal.nonGSWikis = [
 	'dewiktionary',
 	'elwiki',
 	'enwiki',
-	'enwikiquote',
 	'enwikisource',
 	'enwiktionary',
 	'eowiki',


### PR DESCRIPTION
Updating nonGS wikis as of 30 May 2025: removed enwikiquote.